### PR TITLE
Work on topbar responsiveness and CSS adjustments

### DIFF
--- a/app/packs/stylesheets/okbr/_nav.scss
+++ b/app/packs/stylesheets/okbr/_nav.scss
@@ -1,7 +1,11 @@
 #okbr-link {
-  margin: auto 1rem;
+  flex: 2 0 auto;
+  align-self: center;
 }
 
+.org-logo {
+  flex: 2 0 auto;
+}
 .navbar {
   background-color: white;
   color: black;
@@ -61,6 +65,7 @@
     }
     #okbr-link {
       margin: 1.2rem 0 0;
+      align-self: flex-start;
     }
 
     .okbr-search {
@@ -74,4 +79,15 @@
     .main-nav ul > li:not(:last-child) a {
       border-right: 0px;
     }
+}
+
+@media all and (max-width: 820px) {
+  .topbar > div.logo-wrapper {
+    flex-direction: column;
+  }
+
+  #okbr-link {
+    margin: 1.2rem 0 0;
+    align-self: flex-start;
+  }
 }

--- a/app/packs/stylesheets/okbr/_nav.scss
+++ b/app/packs/stylesheets/okbr/_nav.scss
@@ -1,5 +1,5 @@
 #okbr-link {
-  flex: 1 0 auto;
+  margin: auto 1rem;
 }
 
 .navbar {
@@ -24,7 +24,7 @@
 }
 
 .main-nav ul > li > a {
-  padding: 0 1rem;
+  padding: 0 2rem;
 }
 
 .main-nav ul > li:not(:last-child) a {
@@ -54,5 +54,24 @@
 @media all and (max-width: 639px) {
     .topbar__dropmenu > ul > li > a {
         color: white;
+    }
+
+    .topbar > div.logo-wrapper {
+      flex-direction: column;
+    }
+    #okbr-link {
+      margin: 1.2rem 0 0;
+    }
+
+    .okbr-search {
+      width: 100%;
+    }
+
+    .main-nav ul > li > a {
+      margin: 1rem auto;
+    }
+
+    .main-nav ul > li:not(:last-child) a {
+      border-right: 0px;
     }
 }

--- a/app/packs/stylesheets/okbr/application.scss
+++ b/app/packs/stylesheets/okbr/application.scss
@@ -49,3 +49,7 @@ body {
 .floating-helper__content {
   border-top: none;
 }
+
+h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
+  font-family: "Hanken Grotesk", Helvetica, Roboto, Arial, sans-serif;
+}

--- a/app/views/layouts/decidim/_topbar_search.html.erb
+++ b/app/views/layouts/decidim/_topbar_search.html.erb
@@ -1,10 +1,15 @@
-<div class="okbr-search">
-  <%= form_tag(decidim.search_path, method: :get, class: "okbr-search__form") do %>
-    <div class="okbr-search__button-wrapper">
-      <%= submit_tag icon("magnifying-glass", aria_label: t("decidim.search.term_input_placeholder"), role: "img"), title: t("decidim.search.term_input_placeholder"), id: :submit, class: "okbr-search__button" %>
-    </div>
-    <%= label_tag :term do %>
-      <%= text_field_tag :term, nil, class: "okbr-search__input", placeholder: t("decidim.search.term_input_placeholder"), title: t("decidim.search.term_input_placeholder") %>
+<div class="show-for-medium" data-set="nav-search-holder">
+  <div class=" js-append okbr-search">
+    <%= form_tag(decidim.search_path, method: :get, class: "okbr-search__form") do %>
+
+        <div class="okbr-search__button-wrapper">
+          <%= submit_tag icon("magnifying-glass", aria_label: t("decidim.search.term_input_placeholder"), role: "img"), title: t("decidim.search.term_input_placeholder"), id: :submit, class: "okbr-search__button" %>
+        </div>
+      
+        <%= label_tag :term do %>
+          <%= text_field_tag :term, nil, class: "okbr-search__input", placeholder: t("decidim.search.term_input_placeholder"), title: t("decidim.search.term_input_placeholder") %>
+        <% end %>
+
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -45,10 +45,10 @@ end
             <div class="row column topbar">
               <div class="logo-wrapper">
                 <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>
-              </div>
-              <div id="okbr-link">
-                <%= link_to "open knowledge brasil", "https://ok.org.br", target: "_blank", rel: "nofollow" %>
-              </div>
+                <div id="okbr-link">
+                  <%= link_to "open knowledge brasil", "https://ok.org.br/", target: "_blank", rel: "nofollow" %>
+                </div>
+              </div>             
               <%= render partial: "layouts/decidim/topbar_search" %>
               <%= render partial: "layouts/decidim/language_chooser" %>
               <div class="hide-for-medium topbar__menu">

--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -44,11 +44,14 @@ end
             <% end %>
             <div class="row column topbar">
               <div class="logo-wrapper">
-                <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>
+                <div class="org-logo">
+                  <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>
+                </div>
                 <div id="okbr-link">
                   <%= link_to "open knowledge brasil", "https://ok.org.br/", target: "_blank", rel: "nofollow" %>
-                </div>
-              </div>             
+                </div> 
+              </div>            
+
               <%= render partial: "layouts/decidim/topbar_search" %>
               <%= render partial: "layouts/decidim/language_chooser" %>
               <div class="hide-for-medium topbar__menu">

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -702,7 +702,7 @@ pt-BR:
         creator: Administrador
     links:
       warning:
-        body_1: Você está prestes a sair do %{organization_name}.
+        body_1: Você está prestes a sair do cominutas.
         body_2: Como medida de precaução, por favor verifique o link no qual clicou e certifique-se que o reconhece.
     log:
       base_presenter:


### PR DESCRIPTION
This PR works on improving the top-bar UI with the following changes:

- Makes the search bar display inside the hamburger menu for mobile, as intended in the original design
- Moves "OPEN KNOWLEDGE BRASIL" link inside the DIV for the logo to make placement more natural and deals with flexing it from row to column on mobile
- For navbar menu ("Inicio, processos, etc") increases vertical margin on mobile, and horizontal padding on desktop. Also removes lateral borders-right for items on mobile menu

Apart from this, we are applying these other changes:
- It changes all headings to 'HK Grotesk' as per OKBR's requirement
- It corrects the string for external links modal where we were having "%{organization_name}." but no available variable on the original template. This hardcodes the name of "cominutas" to avoid re-writing the template

As for the css topbar changes: 

### Mobile top-bar: 
**Before:** 
![image](https://github.com/okfn-brasil/minutas/assets/8941178/6ca238c0-953e-4434-a9b8-2d699a4e50ee)

**After:** 
![image](https://github.com/okfn-brasil/minutas/assets/8941178/d01be67b-eca4-47a7-a42c-0944d2f7036e)

### Mobile hamburger
**Before:** 
![image](https://github.com/okfn-brasil/minutas/assets/8941178/85a89128-cd47-44a0-8943-83c78d7477fb)

**After:**
![image](https://github.com/okfn-brasil/minutas/assets/8941178/ec84df55-0d23-4d75-95de-f3aaf6e6968b)

### Desktop top-bar 
**Before:**
![image](https://github.com/okfn-brasil/minutas/assets/8941178/bb7d179b-bc68-4ce2-a7db-31834b8b4f9e)

**After:**
![image](https://github.com/okfn-brasil/minutas/assets/8941178/10e41c0f-261a-4ee9-97ec-8fabf1c727b4)
